### PR TITLE
Fix StarMap crash when toggling fleet lines

### DIFF
--- a/libs/client/osci/StarMapWidget.py
+++ b/libs/client/osci/StarMapWidget.py
@@ -972,7 +972,7 @@ class StarMapWidget(Widget):
 		scale = self.scale
 		# draw orders lines
 		if self.showFleetLines:
-			for x1, y1, x2, y2, color, unknown in self._map[self.MAP_FORDERS]:
+			for x1, y1, x2, y2, color, military in self._map[self.MAP_FORDERS]:
 				if not self.showCivilianFleets and not military:
 					continue
 				sx1 = int((x1 - currX) * scale) + centerX


### PR DESCRIPTION
Looks like that unknown variable I had to unpack previously is what the 'military' variable should be, based on what the other code is unpacking in similar fashion and that its values only ever seem to be 1 or 0 when printed out.
