### PR TITLE
Assign Alt+F4 to exiting gracefully

### DIFF
--- a/libs/client/osci/main.py
+++ b/libs/client/osci/main.py
@@ -280,6 +280,11 @@ running = 1
 lastSave = time.clock()
 counter = 0
 needsRefresh = False
+
+# No real way to deal with combinations in this case
+key_alt = False
+key_f4 = False
+
 while running:
     try:
         if gdata.config.game.autologin == 'yes':
@@ -293,10 +298,6 @@ while running:
         forceKeepAlive = False
         saveDB = False
 
-        # No real way to deal with combinations in this case
-        key_alt = False
-        key_f4 = False
-
         for evt in evts:
             if evt.type == QUIT:
                 running = 0
@@ -307,8 +308,13 @@ while running:
                     needsRefresh = True
 
             if evt.type == KEYUP and evt.key == K_F4:
+                key_f4 = False
+            elif evt.type == KEYDOWN and evt.key == K_F4:
                 key_f4 = True
+
             if evt.type == KEYUP and (evt.key == K_LALT or evt.key == K_RALT):
+                key_alt = False
+            elif evt.type == KEYDOWN and (evt.key == K_LALT or evt.key == K_RALT):
                 key_alt = True
 
             if evt.type == KEYUP and evt.key == K_F9:

--- a/libs/client/osci/main.py
+++ b/libs/client/osci/main.py
@@ -293,6 +293,10 @@ while running:
         forceKeepAlive = False
         saveDB = False
 
+        # No real way to deal with combinations in this case
+        key_alt = False
+        key_f4 = False
+
         for evt in evts:
             if evt.type == QUIT:
                 running = 0
@@ -301,12 +305,19 @@ while running:
                 if evt.gain == 1 and evt.state == 6:
                     # pygame desktop window focus event
                     needsRefresh = True
-            if evt.type == KEYUP and evt.key == K_F12:
-                running = 0
-                break
+
+            if evt.type == KEYUP and evt.key == K_F4:
+                key_f4 = True
+            if evt.type == KEYUP and (evt.key == K_LALT or evt.key == K_RALT):
+                key_alt = True
+
             if evt.type == KEYUP and evt.key == K_F9:
                 forceKeepAlive = True
             evt = app.processEvent(evt)
+
+        if (key_f4 and key_alt):
+            running = 0
+            break
 
         if app.needsUpdate() or isHWSurface or needsRefresh:
             needsRefresh = False


### PR DESCRIPTION
Apparently Windows doesn't do anything with the game when Alt+F4 is hit. Linux deals with it with a handle on SIGKILL, so we implement Alt+F4 as a key stroke to hit and remove the F12 binding (it was personally screwing me up as I use F12 as my on-demand dropdown terminal!)
